### PR TITLE
Added "National Institute of Technology Karnakata"

### DIFF
--- a/lib/domains/in/edu/nitk.txt
+++ b/lib/domains/in/edu/nitk.txt
@@ -1,0 +1,1 @@
+National Institute of Technology Karnataka


### PR DESCRIPTION
Added to the list is - National Institute of Technology Karnataka.

Official website address - http://nitk.ac.in
Mail server - http://nitk.edu.in

This JSON from WHOIS API from WHOIS shows proof that http://nitk.edu.in is indeed owned by our college.

http://www.nitk.ac.in/webmail proves on our college site that the domain is indeed owned by our college AND is used by the students

Please note that our college is commonly abbreviated as NITK